### PR TITLE
Unescape subkey string

### DIFF
--- a/Flow.Launcher.Plugin.Putty/PuttySessionService.cs
+++ b/Flow.Launcher.Plugin.Putty/PuttySessionService.cs
@@ -1,4 +1,4 @@
-﻿namespace Flow.Launcher.Plugin.Putty
+namespace Flow.Launcher.Plugin.Putty
 {
     using Microsoft.Win32;
     using System;
@@ -33,7 +33,7 @@
                         {
                             results.Add(new PuttySession
                             {
-                                Identifier = subKey,
+                                Identifier = Uri.UnescapeDataString(subKey),
                                 Protocol = puttySessionSubKey.GetValue("Protocol").ToString(),
                                 Username = puttySessionSubKey.GetValue("UserName").ToString(),
                                 Hostname = puttySessionSubKey.GetValue("HostName").ToString(),

--- a/Flow.Launcher.Plugin.Putty/plugin.json
+++ b/Flow.Launcher.Plugin.Putty/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Putty",
     "Description": "Launch Putty Sessions",
     "Author":"Konstantin Zaitcev, Kai Eichinger (@cH40zLord)",
-    "Version":"2.1.1",
+    "Version":"2.1.2",
     "Language": "csharp",
     "Website": "https://github.com/jjw24/Flow.Launcher.Plugin.Putty",
     "ExecuteFileName": "Flow.Launcher.Plugin.Putty.dll",


### PR DESCRIPTION
The identifier name can be encoded, ie %20 for spaces or %2a for `'`. This fix decodes the string.