### PR TITLE
Fix hostname display for serial port sessions

### DIFF
--- a/Flow.Launcher.Plugin.Putty/Plugin.cs
+++ b/Flow.Launcher.Plugin.Putty/Plugin.cs
@@ -200,13 +200,15 @@ namespace Flow.Launcher.Plugin.Putty
 
                 var p = new Process { StartInfo = { FileName = puttyPath } };
 
-                if (!string.IsNullOrEmpty(puttySession?.Hostname))
+                if (!string.IsNullOrEmpty(puttySession?.Identifier))
                 {
-                    p.StartInfo.Arguments = "-load \"" + puttySession.Identifier + "\"";
+                    p.StartInfo.ArgumentList.Add("-load");
+                    p.StartInfo.ArgumentList.Add(puttySession.Identifier);
                 }
                 else if (!string.IsNullOrEmpty(session))
                 {
-                    p.StartInfo.Arguments = "-ssh \"" + session + "\"";
+                    p.StartInfo.ArgumentList.Add("-ssh");
+                    p.StartInfo.ArgumentList.Add(session);
                 }
 
                 if (settings.AlwaysStartsSessionMaximized)

--- a/Flow.Launcher.Plugin.Putty/PuttySessionService.cs
+++ b/Flow.Launcher.Plugin.Putty/PuttySessionService.cs
@@ -31,13 +31,19 @@ namespace Flow.Launcher.Plugin.Putty
                         }
                         try
                         {
-                            results.Add(new PuttySession
+                            var session = new PuttySession
                             {
                                 Identifier = Uri.UnescapeDataString(subKey),
                                 Protocol = puttySessionSubKey.GetValue("Protocol").ToString(),
                                 Username = puttySessionSubKey.GetValue("UserName").ToString(),
                                 Hostname = puttySessionSubKey.GetValue("HostName").ToString(),
-                            });
+                            };
+                            if (session.Protocol == "serial")
+                            {
+                                session.Hostname = $"{puttySessionSubKey.GetValue("SerialLine")}?baud={puttySessionSubKey.GetValue("SerialSpeed")}";
+                                session.Username = string.Empty; // ensure ToString doesn't append username
+                            }
+                            results.Add(session);
                         }
                         catch (Exception)
                         {

--- a/Flow.Launcher.Plugin.Putty/plugin.json
+++ b/Flow.Launcher.Plugin.Putty/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Putty",
     "Description": "Launch Putty Sessions",
     "Author":"Konstantin Zaitcev, Kai Eichinger (@cH40zLord)",
-    "Version":"2.1.3",
+    "Version":"2.2.0",
     "Language": "csharp",
     "Website": "https://github.com/jjw24/Flow.Launcher.Plugin.Putty",
     "ExecuteFileName": "Flow.Launcher.Plugin.Putty.dll",


### PR DESCRIPTION
Two changes:
- [Construct fake hostname for serial port session](https://github.com/jjw24/Flow.Launcher.Plugin.Putty/commit/105c08077e5a019302ec2f7403048bc9cfae6276), subtitle displays the port and baud rate for serial port sessions now
- [Use ArgumentList to add args cleanly, fix identifier check](https://github.com/jjw24/Flow.Launcher.Plugin.Putty/commit/c20cd96bdd30b4d6aa19c0adf84f05bf7eee5262), escapes arguments cleanly